### PR TITLE
Add traces tests based on Tempo

### DIFF
--- a/example/configs/agent-config.river
+++ b/example/configs/agent-config.river
@@ -1,0 +1,28 @@
+otelcol.receiver.otlp "default" {
+  grpc {
+    endpoint = "0.0.0.0:4017"
+  }
+  http {
+    endpoint = "0.0.0.0:4018"
+  }
+
+  output {
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+  
+otelcol.processor.batch "default" {
+  output {
+    traces  = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+  
+otelcol.exporter.otlp "tempo" {
+    client {
+        endpoint = "tempo:4317"
+        tls {
+            insecure             = true
+            insecure_skip_verify = true
+        }
+    }
+}

--- a/example/configs/instrumenter-config-traces.yml
+++ b/example/configs/instrumenter-config-traces.yml
@@ -1,0 +1,4 @@
+routes:
+  patterns:
+    - /create-trace
+  unmatch: path

--- a/example/configs/tempo-config.yaml
+++ b/example/configs/tempo-config.yaml
@@ -1,0 +1,31 @@
+# Do not use this configuration in production.
+# It is for demonstration purposes only.
+# metrics_generator_enabled: true
+# search_enabled: true
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+        grpc:
+
+metrics_generator:
+  ring:
+    kvstore: {}
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /tmp/tempo/generator/wal
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /tmp/tempo/wal
+    local:
+      path: /tmp/tempo/blocks

--- a/example/docker-compose-java.yml
+++ b/example/docker-compose-java.yml
@@ -3,6 +3,7 @@ version: '3.8'
 services:
   testserver:
     image: grcevski/tests:greeting${JAVA_TEST_MODE}
+    container_name: hatest-testserver
     ports:
       - "8086:8085"
     environment:
@@ -40,7 +41,7 @@ services:
   # OpenTelemetry Collector
   otelcol:
     image: otel/opentelemetry-collector-contrib:0.77.0
-    container_name: otel-col
+    container_name: hatest-otel-col
     deploy:
       resources:
         limits:
@@ -63,7 +64,7 @@ services:
   # Prometheus
   prometheus:
     image: quay.io/prometheus/prometheus:v2.34.0
-    container_name: prometheus
+    container_name: hatest-prometheus
     command:
       - --storage.tsdb.retention.time=1m
       - --config.file=/etc/prometheus/prometheus-config.yml

--- a/example/docker-compose-traces.yml
+++ b/example/docker-compose-traces.yml
@@ -1,0 +1,69 @@
+version: '3.8'
+
+services:
+  # Go based test server
+  testserver:
+    image: grcevski/tests:gotestserver
+    container_name: hatest-testserver
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+      - "8082:8082"
+      - "8083:8083"
+      - "50051:50051"
+    environment:
+      LOG_LEVEL: DEBUG
+
+  # eBPF auto instrumenter
+  autoinstrumenter:
+    image: grafana/ebpf-autoinstrument:latest
+    command:
+      - /otelauto
+      - --config=/configs/instrumenter-config-traces.yml
+    volumes:
+      - ./configs/:/configs
+      - ./testoutput/run:/var/run/otelauto
+    container_name: hatest-autoinstrumenter
+    privileged: true # in some environments (not GH Pull Requests) you can set it to false and then cap_add: [ SYS_ADMIN ]
+    network_mode: "service:testserver"
+    pid: "service:testserver"
+    environment:
+      PRINT_TRACES: "true"
+      OPEN_PORT: "8080"
+      SERVICE_NAMESPACE: "integration-test"
+      METRICS_INTERVAL: "10ms"
+      BPF_BATCH_TIMEOUT: "10ms"
+      LOG_LEVEL: "DEBUG"
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://agent:4018/v1/traces"
+    depends_on:
+      testserver:
+        condition: service_started
+
+  # Agent
+  agent:
+    image: grafana/agent
+    container_name: hatest-agent
+    command:
+      - run
+      - /etc/agent/agent-config.river
+    volumes:
+      - ./configs/:/etc/agent
+    environment:
+      AGENT_MODE: "flow"
+    ports:
+      - "4017:4017"
+      - "4018:4018"
+
+  # Tempo
+  tempo:
+    image: grafana/tempo
+    container_name: hatest-tempo
+    command:
+      - -config.file 
+      - /etc/tempo/tempo-config.yaml
+    volumes:
+      - ./configs/:/etc/tempo
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+      - "4318:4318"

--- a/example/red_java_test.go
+++ b/example/red_java_test.go
@@ -1,4 +1,4 @@
-package javatest
+package inttests
 
 import (
 	"net"
@@ -42,7 +42,7 @@ func waitForJavaTestComponents(t *testing.T, url string) {
 	tests.EnsureReadyWithPrometheus(t, url, "/greeting", prometheusHostPort)
 }
 
-func testREDMetricsForJavaHTTPLibrary(t *testing.T, url string, comm string, systemWide bool) {
+func testREDMetricsForJavaHTTPLibrary(t *testing.T, url string, comm string) {
 	path := "/greeting"
 
 	// Call the instrumented service 4 times asking to respond with HTTP code 204
@@ -63,11 +63,7 @@ func testREDMetricsForJavaHTTPLibrary(t *testing.T, url string, comm string, sys
 			`http_target="` + path + `"}`)
 		require.NoError(t, err)
 		// check duration_count has 3 calls and all the arguments
-		if systemWide {
-			assert.LessOrEqual(t, 1, len(results))
-		} else {
-			require.Len(t, results, 1)
-		}
+		require.Len(t, results, 1)
 		if len(results) > 0 {
 			res := results[0]
 			require.Len(t, res.Value, 2)
@@ -84,7 +80,7 @@ func testREDMetricsJavaHTTP(t *testing.T) {
 	} {
 		t.Run(testCaseURL, func(t *testing.T) {
 			waitForJavaTestComponents(t, testCaseURL)
-			testREDMetricsForJavaHTTPLibrary(t, testCaseURL, "greeting", false)
+			testREDMetricsForJavaHTTPLibrary(t, testCaseURL, "greeting")
 		})
 	}
 }

--- a/example/traces_go_test.go
+++ b/example/traces_go_test.go
@@ -1,0 +1,131 @@
+package inttests
+
+import (
+	"encoding/json"
+	"net/http"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/grafana/otel-test-infra/pkg/infra/docker"
+	"github.com/grafana/otel-test-infra/pkg/infra/tempo"
+	"github.com/grafana/otel-test-infra/pkg/tests"
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tempoQueryURL    = "http://localhost:3200"
+	traceTestTimeout = 20 * time.Second
+)
+
+func TestSuite_Traces(t *testing.T) {
+	compose, err := docker.ComposeSuite("docker-compose-traces.yml", path.Join(pathOutput, "test-suite-traces.log"))
+	require.NoError(t, err)
+	require.NoError(t, compose.Up())
+	t.Run("Go traces", testGoTraces)
+	require.NoError(t, compose.Close())
+}
+
+func testGoTraces(t *testing.T) {
+	for _, testCaseURL := range []string{
+		"http://localhost:8080",
+	} {
+		t.Run(testCaseURL, func(t *testing.T) {
+			tests.EnsureReadyWithTempo(t, testCaseURL, "/smoke", tempoQueryURL)
+			testTracesGoHTTP(t, testCaseURL)
+		})
+	}
+}
+
+func testTracesGoHTTP(t *testing.T, url string) {
+	tests.DoHTTPGet(t, url+"/create-trace?delay=30&response=200", 200, nil)
+
+	var tr tempo.Trace
+	test.Eventually(t, traceTestTimeout, func(t require.TestingT) {
+		resp, err := http.Get(tempoQueryURL + "/api/search?tags=http.target%3D%2Fcreate-trace")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var sr tempo.SearchTagsResult
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&sr))
+		require.GreaterOrEqual(t, len(sr.Traces), 1)
+		tr = sr.Traces[0]
+	}, test.Interval(time.Second))
+
+	require.NotNil(t, tr)
+	resp, err := http.Get(tempoQueryURL + "/api/traces/" + tr.TraceID)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var td tempo.TraceDetails
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&td))
+	require.Len(t, td.Batches, 1)
+
+	batch := td.Batches[0]
+	require.NotNil(t, batch.Resource)
+	tests.AttributesMatch(
+		t,
+		batch.Resource.Attributes,
+		[]tests.AttributeMatch{
+			{Type: "string", Key: "service.namespace", Value: "integration-test"},
+			{Type: "string", Key: "service.name", Value: "testserver"},
+			{Type: "string", Key: "telemetry.sdk.language", Value: "go"},
+		},
+	)
+
+	parents := batch.FindSpansByName("GET /create-trace")
+	require.NotNil(t, parents)
+	require.Len(t, parents, 1)
+	parent := parents[0]
+	require.Equal(t, "SPAN_KIND_SERVER", parent.Kind)
+	tests.TimeIsIncreasing(t, parent)
+
+	tests.AttributesMatch(
+		t,
+		parent.Attributes,
+		[]tests.AttributeMatch{
+			{Type: "string", Key: "http.target", Value: "/create-trace"},
+			{Type: "string", Key: "http.route", Value: "/create-trace"},
+			{Type: "string", Key: "http.method", Value: "GET"},
+			{Type: "int", Key: "net.host.port", Value: "8080"},
+			{Type: "int", Key: "http.status_code", Value: "200"},
+			{Type: "int", Key: "http.request_content_length", Value: "0"},
+		},
+	)
+
+	tests.AttributesExist(
+		t,
+		parent.Attributes,
+		[]tests.AttributeMatch{
+			{Type: "string", Key: "net.host.name"},
+			{Type: "string", Key: "net.sock.peer.addr"},
+		},
+	)
+
+	children := batch.ChildrenOf(parent.SpanId)
+	require.NotNil(t, children)
+	require.GreaterOrEqual(t, 2, len(children))
+
+	inqueue := false
+	processing := false
+	for _, c := range children {
+		require.Equal(t, "SPAN_KIND_INTERNAL", c.Kind)
+		require.Equal(t, parent.SpanId, c.ParentSpanId)
+		tests.TimeIsIncreasing(t, c)
+		require.NotEqual(t, c.ParentSpanId, c.SpanId)
+		require.Equal(t, parent.TraceId, c.TraceId)
+		require.Nil(t, c.Attributes)
+
+		if c.Name == "in queue" {
+			inqueue = true
+		}
+
+		if c.Name == "processing" {
+			processing = true
+		}
+	}
+
+	require.True(t, inqueue)
+	require.True(t, processing)
+}

--- a/pkg/infra/tempo/models.go
+++ b/pkg/infra/tempo/models.go
@@ -1,0 +1,85 @@
+package tempo
+
+type SearchTagsResult struct {
+	Traces []Trace `json:"traces"`
+}
+
+type Trace struct {
+	TraceID           string `json:"traceID"`
+	RootServiceName   string `json:"rootServiceName"`
+	RootTraceName     string `json:"rootTraceName"`
+	StartTimeUnixNano string `json:"startTimeUnixNano"`
+	DurationMs        int    `json:"durationMs"`
+}
+
+type TraceDetails struct {
+	Batches []Batch `json:"batches"`
+}
+
+type Batch struct {
+	Resource   Resource    `json:"resource"`
+	ScopeSpans []ScopeSpan `json:"scopeSpans"`
+}
+
+type Resource struct {
+	Attributes []Attribute `json:"attributes"`
+}
+
+type Attribute struct {
+	Key   string            `json:"key"`
+	Value map[string]string `json:"value"`
+}
+
+type ScopeSpan struct {
+	Scope Scope  `json:"scope"`
+	Spans []Span `json:"spans"`
+}
+
+type Scope struct {
+	Name string `json:"name"`
+}
+
+type Span struct {
+	TraceId           string      `json:"traceId"`
+	SpanId            string      `json:"spanId"`
+	ParentSpanId      string      `json:"parentSpanId"`
+	Name              string      `json:"name"`
+	Kind              string      `json:"kind"`
+	StartTimeUnixNano string      `json:"startTimeUnixNano"`
+	EndTimeUnixNano   string      `json:"endTimeUnixNano"`
+	Attributes        []Attribute `json:"attributes"`
+}
+
+func (b *Batch) FindSpansByName(name string) []Span {
+	var spans []Span
+	if b == nil || b.ScopeSpans == nil {
+		return spans
+	}
+
+	for _, ss := range b.ScopeSpans {
+		for _, s := range ss.Spans {
+			if s.Name == name {
+				spans = append(spans, s)
+			}
+		}
+	}
+
+	return spans
+}
+
+func (b *Batch) ChildrenOf(spanId string) []Span {
+	var spans []Span
+	if b == nil || b.ScopeSpans == nil {
+		return spans
+	}
+
+	for _, ss := range b.ScopeSpans {
+		for _, s := range ss.Spans {
+			if s.ParentSpanId == spanId {
+				spans = append(spans, s)
+			}
+		}
+	}
+
+	return spans
+}

--- a/pkg/tests/traces.go
+++ b/pkg/tests/traces.go
@@ -1,0 +1,87 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/grafana/otel-test-infra/pkg/infra/tempo"
+	"github.com/mariomac/guara/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+func EnsureReadyWithTempo(t *testing.T, url, subpath, tempoURL string) {
+	test.Eventually(t, time.Minute, func(t require.TestingT) {
+		// first, verify that the test service endpoint is healthy
+		req, err := http.NewRequest("GET", url+subpath, nil)
+		require.NoError(t, err)
+		r, err := testHTTPClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, r.StatusCode)
+
+		// now, verify that we see traces in Tempo
+		// we don't really care that this metric could be from a previous
+		// test. Once one it is visible, it means that the Agent and Tempo are healthy and running
+		resp, err := http.Get(tempoURL + "/api/search?tags=http.method%3DGET")
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var sr tempo.SearchTagsResult
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&sr))
+		require.GreaterOrEqual(t, len(sr.Traces), 1)
+	}, test.Interval(time.Second))
+}
+
+func MatchTraceAttribute(t *testing.T, attributes []tempo.Attribute, atype, key, value string) {
+	require.NotNil(t, attributes)
+	found := false
+	for _, attr := range attributes {
+		if attr.Key == key {
+			found = true
+			v := attr.Value
+			require.NotNil(t, v)
+			av, ok := v[atype+"Value"]
+			require.True(t, ok)
+			if value != "" {
+				require.Equal(t, av, value)
+			}
+		}
+	}
+
+	if !found {
+		t.Errorf("couldn't find attribute %s", key)
+	}
+}
+
+type AttributeMatch struct {
+	Key   string
+	Value string
+	Type  string
+}
+
+func AttributesMatch(t *testing.T, attributes []tempo.Attribute, match []AttributeMatch) {
+	for _, m := range match {
+		MatchTraceAttribute(t, attributes, m.Type, m.Key, m.Value)
+	}
+}
+
+func AttributesExist(t *testing.T, attributes []tempo.Attribute, match []AttributeMatch) {
+	for _, m := range match {
+		MatchTraceAttribute(t, attributes, m.Type, m.Key, "")
+	}
+}
+
+func TimeIsIncreasing(t *testing.T, span tempo.Span) {
+	require.NotNil(t, span)
+	require.NotEmpty(t, span.StartTimeUnixNano)
+	require.NotEmpty(t, span.EndTimeUnixNano)
+
+	start, err := strconv.ParseInt(span.StartTimeUnixNano, 10, 64)
+	require.NoError(t, err)
+	end, err := strconv.ParseInt(span.EndTimeUnixNano, 10, 64)
+	require.NoError(t, err)
+
+	require.Greater(t, end, start)
+}


### PR DESCRIPTION
This PR adds few structs and helpers for testing OTel attributes with Tempo as a backend.

It also adds an example Tempo based docker compose with a Go application instrumented with the ebpf-autoinstrumenter.